### PR TITLE
fix(race): resolve race conditions in tests and services

### DIFF
--- a/internal/pipeline/streaming_test.go
+++ b/internal/pipeline/streaming_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -464,7 +465,8 @@ func TestStreamingProcessor_AdvancedErrorHandling(t *testing.T) {
 			Body:       slowReader,
 		}
 
-		w := httptest.NewRecorder()
+		// Use a custom writer that's safe for concurrent access
+		w := &safeTestWriter{ResponseWriter: httptest.NewRecorder()}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 
@@ -473,6 +475,9 @@ func TestStreamingProcessor_AdvancedErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Logf("Context cancellation handled: %v", err)
 		}
+		
+		// Wait a bit to ensure goroutines complete
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	t.Run("WriterCloseErrors", func(t *testing.T) {
@@ -653,4 +658,24 @@ data: [DONE]
 			t.Error("Expected [DONE] marker")
 		}
 	})
+}
+
+// safeTestWriter wraps httptest.ResponseRecorder to be safe for concurrent access
+type safeTestWriter struct {
+	http.ResponseWriter
+	mu sync.Mutex
+}
+
+func (w *safeTestWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *safeTestWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }

--- a/internal/utils/logger.go
+++ b/internal/utils/logger.go
@@ -88,15 +88,18 @@ func InitLogger(config *LogConfig) error {
 
 // GetLogger returns the global logger instance
 func GetLogger() *logrus.Logger {
-	if logger == nil {
-		// Initialize with defaults if not initialized
-		// Safe to ignore error here as we're using default safe configuration
-		_ = InitLogger(&LogConfig{
-			Enabled: false,
-			Level:   "info",
-			Format:  "text",
-		})
-	}
+	// Ensure logger is initialized with defaults if not already done
+	loggerOnce.Do(func() {
+		if logger == nil {
+			logger = logrus.New()
+			logger.SetLevel(logrus.InfoLevel)
+			logger.SetFormatter(&logrus.TextFormatter{
+				TimestampFormat: "2006-01-02 15:04:05",
+				FullTimestamp:   true,
+			})
+			logger.SetOutput(os.Stdout)
+		}
+	})
 	return logger
 }
 


### PR DESCRIPTION
## Summary
- Fixed race conditions detected by Go race detector across multiple packages
- Added proper synchronization to prevent concurrent access issues
- Ensured all tests pass cleanly with `-race` flag

## Changes
1. **Pipeline/Streaming Tests**: Added thread-safe wrapper for `ResponseRecorder` to prevent concurrent write access
2. **Security/Rate Limiter**: 
   - Added `sync.Once` to prevent multiple Stop() calls
   - Added WaitGroup for proper goroutine cleanup
   - Fixed cleanup channel handling
3. **Provider Service**: Added WaitGroup to ensure health check goroutines complete before shutdown
4. **Utils/Logger**: Fixed singleton initialization race with `sync.Once` pattern

## Test Results
All affected packages now pass race detection:
- `internal/pipeline` ✅
- `internal/security` ✅
- `internal/providers` ✅
- `internal/utils` ✅

## Verification
Run tests with race detection to verify:
```bash
go test -race ./internal/pipeline/...
go test -race ./internal/security/...
go test -race ./internal/providers/...
go test -race ./internal/utils/...
```