### PR TITLE
Fix documentation to match actual CCProxy implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ CCProxy is a high-performance Go implementation of the Claude Code Router, provi
 ### Key Features
 
 - **Intelligent Routing**: Automatic model selection based on token count (>60K → longContext), model type, and thinking parameters
-- **Multi-Provider Support**: Anthropic, OpenAI, Gemini, DeepSeek, OpenRouter, Groq, Mistral, XAI, Ollama
+- **Multi-Provider Support**: Anthropic, OpenAI, Gemini, DeepSeek, OpenRouter
 - **Streaming Support**: Server-Sent Events (SSE) for real-time responses
 - **Process Management**: Background service with PID file locking and graceful shutdown
 - **Claude Code Integration**: Auto-start, environment variable management, reference counting
@@ -215,6 +215,22 @@ Enable detailed logging by setting `LOG=true` environment variable. Logs are wri
 - Comprehensive error recovery
 - Process management with proper cleanup
 - Atomic state transitions
+
+## Provider Support
+
+### Full Support (with Transformers)
+These providers have dedicated transformer implementations in `internal/transformer/`:
+- **Anthropic** (`anthropic.go`) - Complete Claude API support
+- **OpenAI** (`openai.go`) - Full GPT model compatibility  
+- **Google Gemini** (`gemini.go`) - Multimodal capabilities
+- **DeepSeek** (`deepseek.go`) - Specialized for coding
+- **OpenRouter** (`openrouter.go`) - Multi-provider access
+
+### Basic Routing Support
+These providers have basic routing in the codebase but lack dedicated transformers:
+- Groq, Mistral, XAI, Ollama - Limited to basic message routing
+
+For production deployments, use providers with full transformer support.
 
 ## Recent Security Fixes (2025-07-21)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ CCProxy is a high-performance Go implementation of the Claude Code Router, provi
 ### Key Features
 
 - **Intelligent Routing**: Automatic model selection based on token count (>60K → longContext), model type, and thinking parameters
-- **Multi-Provider Support**: Anthropic, OpenAI, Gemini, DeepSeek, OpenRouter, Groq
+- **Multi-Provider Support**: Anthropic, OpenAI, Gemini, DeepSeek, OpenRouter, Groq, Mistral, XAI, Ollama
 - **Streaming Support**: Server-Sent Events (SSE) for real-time responses
 - **Process Management**: Background service with PID file locking and graceful shutdown
 - **Claude Code Integration**: Auto-start, environment variable management, reference counting
@@ -103,7 +103,7 @@ make test-race          # Run tests with race detection
 - **Security Tests**: Authentication and authorization flows
 
 ### Dependencies
-- **Go 1.21+** required
+- **Go 1.23+** required
 - **Gin** - HTTP web framework
 - **Cobra** - CLI framework
 - **Viper** - Configuration management

--- a/README.md
+++ b/README.md
@@ -1,202 +1,187 @@
 # CCProxy
 
-CCProxy is a Go-based proxy server that acts as an intelligent intermediary between Claude Code and various Large Language Model (LLM) providers.
+CCProxy is a high-performance Go proxy server that enables Claude Code to work with multiple AI providers through intelligent routing and API translation.
 
 ## 🌟 Features
 
-- **Multi-Provider Support**: Switch between Groq, OpenRouter, OpenAI, and other providers
-- **API Translation**: Seamless conversion between Anthropic and OpenAI-compatible API formats
-- **Tool Support**: Full support for Anthropic tool calling and tool results
-- **Production Ready**: Built for high performance and reliability
+- **Multi-Provider Support**: Anthropic, OpenAI, Google Gemini, Mistral, DeepSeek, Groq, OpenRouter, Ollama, and more
+- **Intelligent Routing**: Automatic model selection based on token count and parameters
+- **API Translation**: Seamless conversion between Anthropic and provider-specific formats
+- **Tool Support**: Full support for function calling across all compatible providers
+- **Streaming Support**: Server-Sent Events (SSE) for real-time responses
 - **Cross Platform**: Binaries available for Linux, macOS, and Windows (AMD64/ARM64)
-- **Docker Support**: Container-ready with multi-stage builds
-- **Comprehensive Logging**: Structured logging with configurable levels
-- **Graceful Shutdown**: Proper signal handling and connection draining
-- **Health Checks**: Built-in health monitoring and provider status endpoints
+- **Process Management**: Background service with automatic startup and graceful shutdown
+- **Health Monitoring**: Built-in health checks and provider status tracking
+- **Security**: API key validation, IP-based access control, rate limiting
 
 ## 🚀 Quick Start
 
 ### Option 1: Download Pre-built Binary
 
-1. Download the latest binary for your platform from the [releases page](https://github.com/your-repo/ccproxy/releases)
-2. Set your provider and API key:
+1. Download the latest binary for your platform from the [releases page](https://github.com/orchestre-dev/ccproxy/releases)
+2. Create a configuration file:
    ```bash
-   # For Groq
-   export PROVIDER=groq
-   export GROQ_API_KEY=your_groq_api_key_here
-   
-   # Or for OpenRouter
-   export PROVIDER=openrouter
-   export OPENROUTER_API_KEY=your_openrouter_api_key_here
+   cp example.config.json config.json
+   # Edit config.json to add your provider API keys
    ```
-3. Run the proxy:
+3. Start CCProxy:
    ```bash
-   ./ccproxy-<platform>
+   ./ccproxy start
    ```
 
 ### Option 2: Build from Source
 
-1. **Prerequisites**: Go 1.21 or later
+1. **Prerequisites**: Go 1.23 or later
 2. **Clone and build**:
    ```bash
-   git clone https://github.com/your-repo/ccproxy.git
+   git clone https://github.com/orchestre-dev/ccproxy.git
    cd ccproxy
-   go build ./cmd/proxy
+   go build ./cmd/ccproxy
    ```
-3. **Set up environment**:
+3. **Configure**:
    ```bash
-   cp .env.example .env
-   # Edit .env and set your PROVIDER and API key
+   cp example.config.json config.json
+   # Edit config.json to add your provider API keys
    ```
-4. **Run the proxy**:
+4. **Start the service**:
    ```bash
-   ./proxy
+   ./ccproxy start
    ```
 
 ### Option 3: Docker
 
-1. **Using Docker Compose** (recommended):
-   ```bash
-   # Set your provider and API key
-   echo "PROVIDER=groq" > .env
-   echo "GROQ_API_KEY=your_groq_api_key_here" >> .env
-   
-   # Start the service
-   docker-compose up -d
-   ```
+```bash
+docker build -t ccproxy .
+docker run -d -p 3456:3456 -v $(pwd)/config.json:/home/ccproxy/.ccproxy/config.json ccproxy
+```
 
-2. **Using Docker directly**:
-   ```bash
-   docker build -f docker/Dockerfile -t ccproxy .
-   docker run -p 7187:7187 -e PROVIDER=groq -e GROQ_API_KEY=your_api_key ccproxy
-   ```
+### Option 4: One-Command Setup with Claude Code
+
+```bash
+# CCProxy will auto-start and configure Claude Code
+./ccproxy code
+```
 
 ## 🔧 Configuration
 
-### Core Environment Variables
+CCProxy uses a JSON configuration file. Create `config.json` based on `example.config.json`:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PROVIDER` | *(required)* | Provider to use: `groq`, `openrouter` |
-| `SERVER_HOST` | `0.0.0.0` | Server bind address |
-| `SERVER_PORT` | `7187` | Server port |
-| `SERVER_ENVIRONMENT` | `development` | Environment mode |
-| `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
-| `LOG_FORMAT` | `json` | Log format (json, text) |
-
-### Provider-Specific Variables
-
-#### Groq Provider
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GROQ_API_KEY` | *(required)* | Your Groq API key |
-| `GROQ_BASE_URL` | `https://api.groq.com/openai/v1` | Groq API base URL |
-| `GROQ_MODEL` | `moonshotai/kimi-k2-instruct` | Model to use |
-| `GROQ_MAX_TOKENS` | `16384` | Maximum tokens per request |
-
-#### OpenRouter Provider
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `OPENROUTER_API_KEY` | *(required)* | Your OpenRouter API key |
-| `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1` | OpenRouter API base URL |
-| `OPENROUTER_MODEL` | `openai/gpt-4o` | Model to use |
-| `OPENROUTER_MAX_TOKENS` | `4096` | Maximum tokens per request |
-| `OPENROUTER_SITE_URL` | | Your site URL (for analytics) |
-| `OPENROUTER_SITE_NAME` | | Your site name (for analytics) |
-
-### Configuration File
-
-You can also use a YAML configuration file:
-
-```yaml
-# config.yaml
-provider: "groq"  # or "openrouter"
-
-server:
-  host: "0.0.0.0"
-  port: "7187"
-  environment: "production"
-
-groq:
-  api_key: "your_groq_api_key_here"
-  model: "moonshotai/kimi-k2-instruct"
-  max_tokens: 16384
-
-openrouter:
-  api_key: "your_openrouter_api_key_here"
-  model: "openai/gpt-4o"
-  max_tokens: 4096
-  site_url: "https://your-site.com"
-  site_name: "Your App Name"
-
-logging:
-  level: "info"
-  format: "json"
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": true,
+  "apikey": "your-api-key-here",
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_base_url": "https://api.anthropic.com",
+      "api_key": "your-anthropic-api-key",
+      "models": ["claude-3-opus-20240229", "claude-3-sonnet-20240229"],
+      "enabled": true
+    },
+    {
+      "name": "openai",
+      "api_base_url": "https://api.openai.com/v1",
+      "api_key": "your-openai-api-key",
+      "models": ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"],
+      "enabled": false
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "anthropic",
+      "model": "claude-3-sonnet-20240229"
+    }
+  }
+}
 ```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CCPROXY_PORT` | `3456` | Override default port |
+| `CCPROXY_HOST` | `127.0.0.1` | Override default host |
+| `CCPROXY_API_KEY` | | Set API key for authentication |
+| `CCPROXY_CONFIG` | | Path to configuration file |
+| `LOG` | `false` | Enable file logging |
 
 ## 🎯 Using with Claude Code
 
-1. **Start the proxy server**:
+### Automatic Setup (Recommended)
+
+```bash
+# CCProxy will auto-start and configure Claude Code environment
+./ccproxy code
+```
+
+### Manual Setup
+
+1. **Start CCProxy**:
    ```bash
-   # For Groq
-   PROVIDER=groq GROQ_API_KEY=your_key ./ccproxy-<platform>
-   
-   # For OpenRouter  
-   PROVIDER=openrouter OPENROUTER_API_KEY=your_key ./ccproxy-<platform>
-   
-   # Or: docker-compose up -d
+   ./ccproxy start
    ```
 
-2. **Configure Claude Code** to use the proxy:
+2. **Configure Claude Code**:
    ```bash
-   export ANTHROPIC_BASE_URL=http://localhost:7187
-   export ANTHROPIC_API_KEY=NOT_NEEDED
+   export ANTHROPIC_BASE_URL=http://localhost:3456
+   export ANTHROPIC_AUTH_TOKEN=test
    ```
 
-3. **Run Claude Code**:
+3. **Use Claude Code**:
    ```bash
-   claude
+   claude "Help me with my code"
    ```
 
-Claude Code will now use your selected AI provider through the proxy!
+## 🏆 Supported Providers
 
-## 🏆 Provider Comparison
+CCProxy supports multiple AI providers with full API translation:
 
-| Provider | Strengths | Best For | Popular Models |
-|----------|-----------|----------|----------------|
-| **Groq** | Ultra-fast inference, cost-effective | Real-time applications, development | `moonshotai/kimi-k2-instruct`, `llama-3.1-405b-reasoning` |
-| **OpenRouter** | Huge model selection, competitive pricing | Access to latest models, experimentation | `openai/gpt-4o`, `anthropic/claude-3-sonnet`, `google/gemini-2.5-pro-preview` |
+- **Anthropic** - Claude models with native support
+- **OpenAI** - GPT-4, GPT-3.5 models
+- **Google Gemini** - Advanced multimodal models
+- **Mistral AI** - European privacy-focused models
+- **DeepSeek** - Cost-effective coding models
+- **Groq** - Ultra-fast inference with LPU technology
+- **OpenRouter** - Access to 100+ models from various providers
+- **XAI** - Grok models with real-time data
+- **Ollama** - Local models for complete privacy
 
-### Important: Tool Calling Requirement
+### Configuration Example
 
-**⚠️ Critical for Claude Code Users**: You must select models that support **tool calling** or **function calling** capabilities, as Claude Code requires these features to operate correctly.
+Add providers to your `config.json`:
 
-### Model Selection Guidelines
-
-When choosing models from any provider:
-
-1. **Verify Tool Support**: Ensure the model supports function calling/tool use
-2. **Check Current Availability**: Model availability changes frequently
-3. **Review Capabilities**: Different models excel at different tasks
-4. **Consider Performance**: Balance speed, quality, and cost for your needs
-
-For current model lists and capabilities, visit each provider's official documentation.
+```json
+{
+  "providers": [
+    {
+      "name": "openai",
+      "api_base_url": "https://api.openai.com/v1",
+      "api_key": "your-api-key",
+      "models": ["gpt-4", "gpt-3.5-turbo"],
+      "enabled": true
+    }
+  ]
+}
+```
 
 ## 📊 API Endpoints
 
-### Main Endpoint
 - `POST /v1/messages` - Anthropic-compatible messages endpoint
-
-### Health & Monitoring
-- `GET /` - Basic health check with current provider info
-- `GET /health` - Detailed health information
-- `GET /status` - Current provider status and configuration
+- `GET /health` - Health check endpoint
+- `GET /status` - Service status information
+- `GET /providers` - List configured providers
+- `POST /providers` - Add new provider
+- `PUT /providers/:name` - Update provider
+- `DELETE /providers/:name` - Remove provider
 
 ### Example Request
 
 ```bash
-curl -X POST http://localhost:7187/v1/messages \
+curl -X POST http://localhost:3456/v1/messages \
   -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
   -d '{
     "model": "claude-3-sonnet-20240229",
     "max_tokens": 1000,
@@ -215,270 +200,71 @@ curl -X POST http://localhost:7187/v1/messages \
 
 ```bash
 # Build for current platform
-go build ./cmd/proxy
-
-# Cross-platform builds
-./scripts/build.sh
-
-# Windows builds
-./scripts/build.bat
-```
-
-### Testing
-
-**🚧 Test Suite Status**: The test suite has been temporarily removed due to system stability issues. A new test framework is being developed.
-
-**Current Testing Approach**:
-
-```bash
-# Build and verify compilation
 make build
 
-# Run basic functionality test
-./build/ccproxy version
-
-# Cross-platform builds (all except Windows)
+# Cross-platform builds
 make build-all
 
-# Code formatting and basic linting
-make fmt
-make lint
-```
-
-**Quality Assurance**:
-- ✅ **Compilation**: All packages compile successfully
-- ✅ **Cross-platform**: Builds for Linux, macOS (Intel/Apple Silicon)
-- ✅ **Version Management**: Semantic versioning system functional
-- ✅ **Release Automation**: CI/CD pipeline operational
-- 🔄 **Test Coverage**: New test suite under development
-
-### Hot Reload Development
-
-Install Air for hot reloading:
-```bash
-go install github.com/cosmtrek/air@latest
-air
-```
-
-## 🐛 Troubleshooting
-
-### Common Issues
-
-1. **"PROVIDER environment variable is required"**
-   - Ensure you've set the PROVIDER variable to `groq` or `openrouter`
-   - Set the corresponding API key for your chosen provider
-
-2. **"API_KEY environment variable is required"**
-   - For Groq: Set `GROQ_API_KEY` - Get your key from [Groq Console](https://console.groq.com/)
-   - For OpenRouter: Set `OPENROUTER_API_KEY` - Get your key from [OpenRouter](https://openrouter.ai/)
-
-3. **Connection refused on localhost:7187**
-   - Check if the proxy is running: `curl http://localhost:7187/`
-   - Verify the port isn't in use: `lsof -i :7187`
-
-4. **"Failed to call provider API"**
-   - Verify your API key is valid for the selected provider
-   - Check internet connectivity
-   - Review proxy logs for detailed error messages
-   - Ensure the model name is supported by your provider
-
-### Debug Mode
-
-Enable debug logging for troubleshooting:
-```bash
-export LOG_LEVEL=debug
-./ccproxy-<platform>
-```
-
-### Health Check
-
-Check if the service is healthy:
-```bash
-curl http://localhost:7187/health
-```
-
-## 📈 Performance
-
-### Benchmarks
-
-The Golang implementation provides significant performance improvements over the Python version:
-
-- **Memory Usage**: ~10-20MB (vs ~50-100MB Python)
-- **Startup Time**: <100ms (vs ~2-3s Python)
-- **Request Latency**: <10ms conversion overhead
-- **Throughput**: >1000 requests/second
-
-### Optimization
-
-For production deployments:
-
-1. Use the `production` environment
-2. Set appropriate resource limits
-3. Enable horizontal scaling with load balancers
-4. Monitor memory and CPU usage
-
-## 🔒 Security
-
-### Best Practices
-
-- Keep your API keys secure and rotate regularly
-- Use HTTPS in production environments
-- Set up proper firewall rules
-- Monitor for unusual API usage patterns
-- Use environment variables for sensitive configuration
-- Choose the right provider for your use case (cost, speed, model availability)
-
-### Production Deployment
-
-For production use:
-
-```bash
-# Use production environment
-export SERVER_ENVIRONMENT=production
-
-# Bind to specific interface
-export SERVER_HOST=127.0.0.1
-
-# Use structured JSON logging
-export LOG_FORMAT=json
-export LOG_LEVEL=warn
-```
-
-## 🚀 Deployment
-
-### Systemd Service
-
-Create `/etc/systemd/system/ccproxy.service`:
-
-```ini
-[Unit]
-Description=CCProxy Multi-Provider AI Proxy Server
-After=network.target
-
-[Service]
-Type=simple
-User=ccproxy
-Group=ccproxy
-ExecStart=/usr/local/bin/ccproxy
-Restart=always
-RestartSec=5
-Environment=PROVIDER=groq
-Environment=GROQ_API_KEY=your_api_key_here
-Environment=LOG_LEVEL=info
-Environment=SERVER_ENVIRONMENT=production
-
-[Install]
-WantedBy=multi-user.target
-```
-
-### Kubernetes
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ccproxy
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: ccproxy
-  template:
-    metadata:
-      labels:
-        app: ccproxy
-    spec:
-      containers:
-      - name: ccproxy
-        image: ccproxy:latest
-        ports:
-        - containerPort: 7187
-        env:
-        - name: PROVIDER
-          value: "groq"
-        - name: GROQ_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ccproxy-secrets
-              key: groq-api-key
-        - name: SERVER_ENVIRONMENT
-          value: "production"
-```
-
-## 🔄 Migration from Python Version
-
-The Golang version is a drop-in replacement for the Python version:
-
-1. **Same API**: Identical endpoints and request/response formats
-2. **Same Configuration**: Uses the same environment variables
-3. **Same Port**: Default port 7187
-4. **Better Performance**: Significantly faster and uses less memory
-
-### Side-by-Side Testing
-
-You can run both versions simultaneously for testing:
-
-```bash
-# Python version on port 7187
-python proxy.py
-
-# Golang version on port 7188
-SERVER_PORT=7188 ./ccproxy
-```
-
-## 📋 Comparison with Original
-
-| Feature | Python Version | Golang Version |
-|---------|---------------|----------------|
-| **Startup Time** | ~2-3 seconds | <100ms |
-| **Memory Usage** | ~50-100MB | ~10-20MB |
-| **CPU Usage** | Higher | Lower |
-| **Dependencies** | Many (FastAPI, etc.) | Minimal |
-| **Binary Size** | N/A | ~9MB |
-| **Cross-compilation** | No | Yes |
-| **Static Binary** | No | Yes |
-| **Deployment** | Complex | Simple |
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/amazing-feature`
-3. Commit your changes: `git commit -m 'Add amazing feature'`
-4. Push to the branch: `git push origin feature/amazing-feature`
-5. Open a Pull Request
-
-### Development Setup
-
-```bash
-# Clone the repo
-git clone https://github.com/your-repo/ccproxy.git
-cd ccproxy
-
-# Install dependencies
-go mod download
-
 # Run tests
-go test ./...
+make test
 
-# Build
-go build ./cmd/proxy
+# Run tests with race detection
+make test-race
 ```
+
+### Commands
+
+- `ccproxy start` - Start the service
+- `ccproxy stop` - Stop the service
+- `ccproxy status` - Check service status
+- `ccproxy code` - Configure Claude Code
+- `ccproxy version` - Show version
+- `ccproxy env` - Show environment variables
 
 ## 📄 License
 
 MIT License - see [LICENSE](LICENSE) file for details.
 
+## 🤝 Contributing
+
+Contributions are welcome! Please read our [Contributing Guidelines](docs/guide/contributing.md) first.
+
 ## 🙏 Acknowledgments
 
-- Inspired by [claude-code-proxy](https://github.com/1rgs/claude-code-proxy)
-- Built with [Gin Web Framework](https://github.com/gin-gonic/gin)
-- Supports multiple providers: [Groq](https://groq.com/), [OpenRouter](https://openrouter.ai/), and more
+Built with ❤️ for the Claude Code community.
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+1. **Service won't start**
+   - Check if port 3456 is available: `lsof -i :3456`
+   - Verify configuration file syntax
+   - Check logs: `tail -f ~/.ccproxy/ccproxy.log`
+
+2. **Authentication errors**
+   - Verify API keys in config.json
+   - Check provider is enabled in configuration
+   - Ensure API key has correct permissions
+
+3. **Connection refused**
+   - Check service status: `./ccproxy status`
+   - Verify firewall settings
+   - Ensure service is bound to correct interface
+
+### Debug Mode
+
+Enable debug logging:
+```bash
+LOG=true ./ccproxy start
+# Check logs at ~/.ccproxy/ccproxy.log
+```
 
 ## 📞 Support
 
-- 📖 [Documentation](./docs/)
-- 🐛 [Issue Tracker](https://github.com/your-repo/ccproxy/issues)
-- 💬 [Discussions](https://github.com/your-repo/ccproxy/discussions)
+- 📖 [Documentation](https://ccproxy.orchestre.dev)
+- 🐛 [Issue Tracker](https://github.com/orchestre-dev/ccproxy/issues)
+- 💬 [Discussions](https://github.com/orchestre-dev/ccproxy/discussions)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CCProxy is a high-performance Go proxy server that enables Claude Code to work w
 
 ## 🌟 Features
 
-- **Multi-Provider Support**: Anthropic, OpenAI, Google Gemini, Mistral, DeepSeek, Groq, OpenRouter, Ollama, and more
+- **Multi-Provider Support**: Anthropic, OpenAI, Google Gemini, DeepSeek, OpenRouter
 - **Intelligent Routing**: Automatic model selection based on token count and parameters
 - **API Translation**: Seamless conversion between Anthropic and provider-specific formats
 - **Tool Support**: Full support for function calling across all compatible providers
@@ -141,12 +141,26 @@ CCProxy supports multiple AI providers with full API translation:
 - **Anthropic** - Claude models with native support
 - **OpenAI** - GPT-4, GPT-3.5 models
 - **Google Gemini** - Advanced multimodal models
-- **Mistral AI** - European privacy-focused models
 - **DeepSeek** - Cost-effective coding models
-- **Groq** - Ultra-fast inference with LPU technology
 - **OpenRouter** - Access to 100+ models from various providers
-- **XAI** - Grok models with real-time data
-- **Ollama** - Local models for complete privacy
+
+### Provider Support Levels
+
+CCProxy offers different levels of support for various providers:
+
+#### Full Support (with dedicated transformers)
+These providers have complete API translation and all features work seamlessly:
+- **Anthropic** - Native Claude API support
+- **OpenAI** - Complete GPT model compatibility
+- **Google Gemini** - Full multimodal support
+- **DeepSeek** - Optimized for coding tasks
+- **OpenRouter** - Unified access to multiple providers
+
+#### Basic Routing Support
+These providers have basic routing capabilities but may have limited functionality:
+- Groq, Mistral, XAI, Ollama - Basic message routing only
+
+For production use, we recommend using providers with full support.
 
 ### Configuration Example
 

--- a/docs/api/messages.md
+++ b/docs/api/messages.md
@@ -10,7 +10,12 @@ POST /v1/messages
 
 ## Authentication
 
-CCProxy doesn't require authentication. The API key authentication is handled by the underlying provider using the configured environment variables.
+CCProxy supports API key authentication when configured:
+
+- **Bearer Token**: `Authorization: Bearer your-api-key`
+- **API Key Header**: `x-api-key: your-api-key`
+
+If no API key is configured in `config.json`, the service is only accessible from localhost.
 
 ## Request Format
 
@@ -395,44 +400,42 @@ curl -X POST http://localhost:3456/v1/messages \
 
 ### Model Mapping
 
-The `model` parameter is mapped to the actual provider model:
+CCProxy automatically maps Anthropic model names to provider-specific models. The mapping is configured in your `config.json` file.
 
-| Provider | Input Model | Actual Model |
-|----------|-------------|--------------|
-| Groq | claude-3-sonnet | moonshotai/kimi-k2-instruct |
+Example mappings:
+
+| Provider | Anthropic Model | Mapped Model |
+|----------|----------------|--------------|
+| Anthropic | claude-3-sonnet | claude-3-sonnet-20240229 |
 | OpenRouter | claude-3-sonnet | anthropic/claude-3.5-sonnet |
-| OpenAI | claude-3-sonnet | gpt-4o |
-| XAI | claude-3-sonnet | grok-beta |
+| OpenAI | claude-3-sonnet | gpt-4 |
 | Gemini | claude-3-sonnet | gemini-1.5-flash |
-| Mistral | claude-3-sonnet | mistral-large-latest |
-| Ollama | claude-3-sonnet | llama3.2 |
+| DeepSeek | claude-3-sonnet | deepseek-coder |
 
 ### Feature Support
 
-Not all providers support all features:
+Provider capabilities vary:
 
-| Feature | Groq | OpenRouter | OpenAI | XAI | Gemini | Mistral | Ollama |
-|---------|------|------------|--------|-----|--------|---------|--------|
-| Text | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Tools | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Vision | ❌ | ✅* | ✅ | ✅ | ✅ | ❌ | ✅* |
-| Streaming | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Feature | Anthropic | OpenRouter | OpenAI | Gemini | DeepSeek |
+|---------|-----------|------------|--------|--------|-----------|
+| Text | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Tools | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Vision | ✅ | ✅* | ✅ | ✅ | ❌ |
+| Streaming | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 *Depends on specific model
 
 ## Rate Limits
 
-Rate limits are enforced by the underlying providers:
+Rate limits are enforced by the underlying providers and vary by plan:
 
-| Provider | Requests/min | Tokens/min |
-|----------|--------------|------------|
-| Groq | 30 | 6,000 |
-| OpenRouter | Varies | Varies |
-| OpenAI | 10,000 | 30,000,000 |
-| XAI | Unknown | Unknown |
-| Gemini | 15 | 32,000 |
-| Mistral | Unknown | Unknown |
-| Ollama | No limits | No limits |
+| Provider | Default Limits | Notes |
+|----------|----------------|-------|
+| Anthropic | Per API key | Check your Anthropic dashboard |
+| OpenRouter | Model-specific | Varies by model |
+| OpenAI | Tier-based | Based on usage tier |
+| Gemini | 15 RPM (free) | Higher limits for paid plans |
+| DeepSeek | API key based | Check provider documentation |
 
 ## Best Practices
 

--- a/docs/api/messages.md
+++ b/docs/api/messages.md
@@ -130,7 +130,7 @@ Responses follow the Anthropic Messages API format:
   "id": "msg_123abc",
   "type": "message",
   "role": "assistant",
-  "model": "groq/llama-3.1-70b-versatile",
+  "model": "anthropic/claude-3-sonnet-20240229",
   "content": [
     {
       "type": "text",
@@ -153,7 +153,7 @@ Responses follow the Anthropic Messages API format:
   "id": "msg_456def",
   "type": "message",
   "role": "assistant", 
-  "model": "groq/llama-3.1-70b-versatile",
+  "model": "anthropic/claude-3-sonnet-20240229",
   "content": [
     {
       "type": "tool_use",

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,300 +1,477 @@
 ---
 title: Configuration Guide - CCProxy Provider Setup
-description: Complete configuration guide for CCProxy. Set up Groq Kimi K2, OpenAI, Gemini, Mistral, XAI Grok, OpenRouter, and Ollama providers with Claude Code.
-keywords: CCProxy configuration, Groq setup, OpenAI config, Gemini setup, Mistral config, XAI Grok, OpenRouter, Ollama, Claude Code integration
+description: Complete configuration guide for CCProxy. Set up Anthropic, OpenAI, Gemini, DeepSeek, and OpenRouter providers with Claude Code.
+keywords: CCProxy configuration, Anthropic setup, OpenAI config, Gemini setup, DeepSeek config, OpenRouter, Claude Code integration
 ---
 
 # Configuration Guide
 
 <SocialShare />
 
-Configure CCProxy to work with your preferred AI provider. CCProxy supports 7+ major providers, each with their own configuration options and capabilities.
+Configure CCProxy to work with your preferred AI providers. CCProxy uses a JSON configuration file to manage providers, routing, and server settings.
 
-## Quick Setup
+## Configuration File
 
-The fastest way to get started is using our installation script:
+CCProxy uses a `config.json` file for all configuration. The file is typically located at:
+- Linux/macOS: `~/.ccproxy/config.json`
+- Windows: `%USERPROFILE%\.ccproxy\config.json`
+- Or specify a custom location with `--config` flag
 
-```bash
-# Install CCProxy with auto-detection
-curl -sSL https://raw.githubusercontent.com/orchestre-dev/ccproxy/main/install.sh | bash
+## Basic Configuration
 
-# Then configure your provider (see examples below)
-export PROVIDER=groq
-export GROQ_API_KEY=your_api_key
-ccproxy
+### Minimal Configuration
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_key": "sk-ant-...",
+      "enabled": true
+    }
+  ]
+}
 ```
 
-## Environment Variables
+### Full Configuration Example
 
-CCProxy uses environment variables for configuration. Create a `.env` file or export variables directly:
-
-### Core Configuration
-
-```bash
-# Required: Choose your provider
-PROVIDER=groq
-
-# Optional: Server configuration
-PORT=3456                    # Default: 3456
-LOG_LEVEL=info              # Options: debug, info, warn, error
-LOG_FORMAT=json             # Options: json, text
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": true,
+  "apikey": "your-ccproxy-api-key",
+  "performance": {
+    "request_timeout": "30s",
+    "max_request_body_size": 10485760,
+    "metrics_enabled": true,
+    "rate_limit_enabled": false,
+    "circuit_breaker_enabled": true
+  },
+  "security": {
+    "audit_enabled": false,
+    "ip_whitelist": ["127.0.0.1"],
+    "allowed_headers": ["Content-Type", "Accept", "Authorization"]
+  },
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_key": "${ANTHROPIC_API_KEY}",
+      "api_base_url": "https://api.anthropic.com",
+      "models": ["claude-3-opus-20240229", "claude-3-sonnet-20240229"],
+      "enabled": true
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "anthropic",
+      "model": "claude-3-sonnet-20240229"
+    },
+    "longContext": {
+      "provider": "anthropic",
+      "model": "claude-3-opus-20240229"
+    }
+  }
+}
 ```
 
-## Provider-Specific Configuration
+## Provider Configuration
 
-### 🚀 Groq (Recommended for Kimi K2)
+### 🎯 Anthropic (Claude)
 
-**Ultra-fast inference with Kimi K2 support**
+**Native support for all Claude models**
 
-```bash
-# Required
-PROVIDER=groq
-GROQ_API_KEY=gsk_your_groq_api_key_here
-
-# Optional
-GROQ_MODEL=moonshotai/kimi-k2-instruct    # Default model
-GROQ_MAX_TOKENS=8192                      # Default: 16384
-GROQ_BASE_URL=https://api.groq.com/openai/v1  # Default URL
+```json
+{
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_key": "sk-ant-...",
+      "api_base_url": "https://api.anthropic.com",
+      "models": [
+        "claude-3-opus-20240229",
+        "claude-3-sonnet-20240229",
+        "claude-3-haiku-20240307"
+      ],
+      "enabled": true
+    }
+  ]
+}
 ```
 
-**Get your API key:** [console.groq.com](https://console.groq.com/)
-
-**Available Models:** [View current models and pricing →](https://console.groq.com/docs/models)
-
-### 🌐 OpenRouter
-
-**Access to 100+ models including Kimi K2**
-
-```bash
-# Required
-PROVIDER=openrouter
-OPENROUTER_API_KEY=sk-or-v1-your_openrouter_key_here
-
-# Optional
-OPENROUTER_MODEL=moonshotai/kimi-k2-instruct  # Default model
-OPENROUTER_MAX_TOKENS=8192                    # Default: 16384
-OPENROUTER_SITE_URL=https://yoursite.com      # For tracking
-OPENROUTER_SITE_NAME=YourApp                  # For tracking
-```
-
-**Get your API key:** [openrouter.ai](https://openrouter.ai/)
-
-**Available Models:** [Browse 100+ models and pricing →](https://openrouter.ai/models)
+**Get your API key:** [console.anthropic.com](https://console.anthropic.com/)
 
 ### 🤖 OpenAI
 
-**Industry-standard GPT models**
+**GPT-4 and GPT-3.5 models with full compatibility**
 
-```bash
-# Required
-PROVIDER=openai
-OPENAI_API_KEY=sk-your_openai_api_key_here
-
-# Optional
-OPENAI_MODEL=gpt-4.1                         # Default model (2025)
-OPENAI_MAX_TOKENS=16384                      # Default: 16384
-OPENAI_ORGANIZATION=org-your_org_id          # Optional
-OPENAI_BASE_URL=https://api.openai.com/v1    # Default URL
+```json
+{
+  "providers": [
+    {
+      "name": "openai",
+      "api_key": "sk-...",
+      "api_base_url": "https://api.openai.com/v1",
+      "models": [
+        "gpt-4",
+        "gpt-4-turbo-preview",
+        "gpt-3.5-turbo"
+      ],
+      "enabled": true
+    }
+  ]
+}
 ```
 
 **Get your API key:** [platform.openai.com](https://platform.openai.com/)
 
-**Available Models:** [View current models and pricing →](https://platform.openai.com/docs/models)
+### 🌟 Google Gemini
 
-### 🧠 Google Gemini
+**Advanced multimodal models**
 
-**Advanced multimodal AI**
-
-```bash
-# Required
-PROVIDER=gemini
-GEMINI_API_KEY=your_gemini_api_key_here
-
-# Optional
-GEMINI_MODEL=gemini-2.0-flash                # Default model (2025)
-GEMINI_MAX_TOKENS=32768                      # Default: 16384
-GEMINI_BASE_URL=https://generativelanguage.googleapis.com  # Default
+```json
+{
+  "providers": [
+    {
+      "name": "gemini",
+      "api_key": "AI...",
+      "api_base_url": "https://generativelanguage.googleapis.com",
+      "models": [
+        "gemini-1.5-flash",
+        "gemini-1.5-pro"
+      ],
+      "enabled": true
+    }
+  ]
+}
 ```
 
-**Get your API key:** [aistudio.google.com](https://aistudio.google.com/)
+**Get your API key:** [makersuite.google.com](https://makersuite.google.com/app/apikey)
 
-**Available Models:** [View current models and pricing →](https://ai.google.dev/gemini-api/docs/models)
+### 💻 DeepSeek
 
-### 🇪🇺 Mistral AI
+**Specialized coding models**
 
-**European privacy-focused AI**
-
-```bash
-# Required
-PROVIDER=mistral
-MISTRAL_API_KEY=your_mistral_api_key_here
-
-# Optional
-MISTRAL_MODEL=mistral-large-latest           # Default model
-MISTRAL_MAX_TOKENS=32768                     # Default: 16384
-MISTRAL_BASE_URL=https://api.mistral.ai/v1   # Default URL
+```json
+{
+  "providers": [
+    {
+      "name": "deepseek",
+      "api_key": "sk-...",
+      "api_base_url": "https://api.deepseek.com",
+      "models": [
+        "deepseek-coder",
+        "deepseek-chat"
+      ],
+      "enabled": true
+    }
+  ]
+}
 ```
 
-**Get your API key:** [console.mistral.ai](https://console.mistral.ai/)
+**Get your API key:** [platform.deepseek.com](https://platform.deepseek.com/)
 
-**Available Models:** [View current models and pricing →](https://docs.mistral.ai/getting-started/models/models_overview/)
+### 🌐 OpenRouter
 
-### 🔥 XAI (Grok)
+**Access to 100+ models through unified API**
 
-**Real-time data access with X integration**
-
-```bash
-# Required
-PROVIDER=xai
-XAI_API_KEY=xai-your_xai_api_key_here
-
-# Optional
-XAI_MODEL=grok-4                            # Default model (2025)
-XAI_MAX_TOKENS=16384                        # Default: 16384
-XAI_BASE_URL=https://api.x.ai/v1            # Default URL
+```json
+{
+  "providers": [
+    {
+      "name": "openrouter",
+      "api_key": "sk-or-v1-...",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "models": [
+        "anthropic/claude-3.5-sonnet",
+        "google/gemini-pro-1.5",
+        "meta-llama/llama-3.1-405b-instruct"
+      ],
+      "enabled": true
+    }
+  ]
+}
 ```
 
-**Get your API key:** [console.x.ai](https://console.x.ai/) ($25 free credits/month)
+**Get your API key:** [openrouter.ai](https://openrouter.ai/)
 
-**Available Models:** [View current models and pricing →](https://docs.x.ai/docs/models)
+## Environment Variables
 
-### 🏠 Ollama
+CCProxy supports environment variable substitution in configuration files:
 
-**Local models for complete privacy**
-
-```bash
-# Required
-PROVIDER=ollama
-OLLAMA_MODEL=llama3.3                       # Must be downloaded locally
-
-# Optional
-OLLAMA_BASE_URL=http://localhost:11434      # Default Ollama URL
-OLLAMA_MAX_TOKENS=16384                     # Default: 16384
+```json
+{
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_key": "${ANTHROPIC_API_KEY}",
+      "enabled": true
+    }
+  ]
+}
 ```
 
-**Setup Requirements:**
-1. Install Ollama: [ollama.ai](https://ollama.ai/)
-2. Download a model: `ollama pull llama3.3`
-3. Start Ollama: `ollama serve`
+Then set the environment variable:
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+./ccproxy start
+```
 
-**Available Models:** [Browse all local models →](https://ollama.com/library)
+## Routing Configuration
+
+CCProxy can route requests based on various criteria:
+
+### Default Routing
+```json
+{
+  "routes": {
+    "default": {
+      "provider": "anthropic",
+      "model": "claude-3-sonnet-20240229"
+    }
+  }
+}
+```
+
+### Context-Based Routing
+Requests with >60K tokens automatically route to long-context models:
+```json
+{
+  "routes": {
+    "default": {
+      "provider": "anthropic",
+      "model": "claude-3-sonnet-20240229"
+    },
+    "longContext": {
+      "provider": "anthropic",
+      "model": "claude-3-opus-20240229"
+    }
+  }
+}
+```
+
+### Model-Specific Routing
+```json
+{
+  "routes": {
+    "claude-3-opus": {
+      "provider": "anthropic",
+      "model": "claude-3-opus-20240229"
+    },
+    "gpt-4": {
+      "provider": "openai",
+      "model": "gpt-4"
+    }
+  }
+}
+```
+
+## Performance Configuration
+
+Optimize CCProxy performance:
+
+```json
+{
+  "performance": {
+    "request_timeout": "30s",
+    "max_request_body_size": 10485760,
+    "metrics_enabled": true,
+    "rate_limit_enabled": false,
+    "circuit_breaker_enabled": true,
+    "circuit_breaker_threshold": 5,
+    "circuit_breaker_timeout": "60s"
+  }
+}
+```
+
+## Security Configuration
+
+Configure security settings:
+
+```json
+{
+  "apikey": "your-secure-api-key",
+  "security": {
+    "audit_enabled": true,
+    "ip_whitelist": ["127.0.0.1", "192.168.1.0/24"],
+    "ip_blacklist": ["10.0.0.0/8"],
+    "allowed_headers": ["Content-Type", "Accept", "Authorization"],
+    "cors_enabled": true,
+    "cors_origins": ["http://localhost:3000"]
+  }
+}
+```
+
+## Multiple Configurations
+
+Manage different environments with separate configuration files:
+
+### Development Configuration
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": true,
+  "providers": [{
+    "name": "anthropic",
+    "api_key": "${ANTHROPIC_API_KEY}",
+    "enabled": true
+  }]
+}
+```
+
+### Production Configuration
+```json
+{
+  "host": "0.0.0.0",
+  "port": 443,
+  "apikey": "${CCPROXY_API_KEY}",
+  "log": false,
+  "performance": {
+    "rate_limit_enabled": true,
+    "circuit_breaker_enabled": true
+  },
+  "security": {
+    "audit_enabled": true,
+    "ip_whitelist": ["10.0.0.0/8"]
+  }
+}
+```
+
+Use different configs:
+```bash
+./ccproxy start --config config.dev.json
+./ccproxy start --config config.prod.json
+```
 
 ## Claude Code Integration
 
 Once CCProxy is configured and running, integrate with Claude Code:
 
+### Automatic Setup
+```bash
+./ccproxy code
+```
+
+### Manual Setup
 ```bash
 # Set Claude Code to use CCProxy
 export ANTHROPIC_BASE_URL=http://localhost:3456
-export ANTHROPIC_API_KEY=NOT_NEEDED
+export ANTHROPIC_AUTH_TOKEN=test
+export API_TIMEOUT_MS=600000
 
 # Verify it's working
-claude-code "Hello, can you help me with coding?"
+claude "Hello, can you help me with coding?"
 ```
 
 ## Advanced Configuration
 
-### Custom Configuration File
+### Complete Configuration Reference
 
-Create a `config.yaml` file for advanced settings:
-
-```yaml
-# config.yaml
-server:
-  port: 3456
-  host: "0.0.0.0"
-  read_timeout: "30s"
-  write_timeout: "30s"
-
-logging:
-  level: "info"
-  format: "json"
-  file: "ccproxy.log"
-
-provider:
-  name: "groq"
-  timeout: "30s"
-  max_retries: 3
-  retry_delay: "1s"
-
-# Provider-specific settings
-groq:
-  api_key: "${GROQ_API_KEY}"
-  model: "moonshotai/kimi-k2-instruct"
-  max_tokens: 8192
-  base_url: "https://api.groq.com/openai/v1"
-```
-
-Run with config file:
-```bash
-ccproxy --config config.yaml
-```
-
-### Multiple Provider Setup
-
-For switching between providers easily:
-
-```bash
-# Create multiple .env files
-cp .env .env.groq
-cp .env .env.openai
-cp .env .env.gemini
-
-# Switch providers
-source .env.groq && ccproxy    # Use Groq
-source .env.openai && ccproxy  # Use OpenAI
-source .env.gemini && ccproxy  # Use Gemini
-```
-
-### Load Balancing (Coming Soon)
-
-Configure multiple providers for failover:
-
-```yaml
-providers:
-  - name: "groq"
-    weight: 70
-    config:
-      api_key: "${GROQ_API_KEY}"
-      model: "moonshotai/kimi-k2-instruct"
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": true,
+  "apikey": "your-ccproxy-api-key",
   
-  - name: "openrouter"
-    weight: 30
-    config:
-      api_key: "${OPENROUTER_API_KEY}"
-      model: "moonshotai/kimi-k2-instruct"
+  "performance": {
+    "request_timeout": "30s",
+    "max_request_body_size": 10485760,
+    "metrics_enabled": true,
+    "rate_limit_enabled": false,
+    "rate_limit_requests_per_minute": 60,
+    "circuit_breaker_enabled": true,
+    "circuit_breaker_threshold": 5,
+    "circuit_breaker_timeout": "60s",
+    "cache_enabled": true,
+    "cache_ttl": "5m"
+  },
+  
+  "security": {
+    "audit_enabled": false,
+    "audit_log_path": "~/.ccproxy/audit.log",
+    "ip_whitelist": [],
+    "ip_blacklist": [],
+    "allowed_headers": ["Content-Type", "Accept", "Authorization"],
+    "cors_enabled": true,
+    "cors_origins": ["*"],
+    "cors_credentials": false
+  },
+  
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_key": "${ANTHROPIC_API_KEY}",
+      "api_base_url": "https://api.anthropic.com",
+      "models": ["claude-3-opus-20240229", "claude-3-sonnet-20240229"],
+      "enabled": true,
+      "priority": 1,
+      "timeout": "30s",
+      "max_retries": 3
+    }
+  ],
+  
+  "routes": {
+    "default": {
+      "provider": "anthropic",
+      "model": "claude-3-sonnet-20240229"
+    },
+    "longContext": {
+      "provider": "anthropic",
+      "model": "claude-3-opus-20240229"
+    }
+  },
+  
+  "middleware": {
+    "request_id": true,
+    "logging": true,
+    "recovery": true,
+    "timeout": true,
+    "cors": true,
+    "security": true,
+    "performance": true
+  }
+}
 ```
 
-## Environment Files
+### Configuration Directory Structure
 
-Create provider-specific `.env` files:
-
-### .env.kimi-groq
-```bash
-# Ultra-fast Kimi K2 via Groq
-PROVIDER=groq
-GROQ_API_KEY=gsk_your_key_here
-GROQ_MODEL=moonshotai/kimi-k2-instruct
-LOG_LEVEL=info
+```
+~/.ccproxy/
+├── config.json          # Main configuration
+├── config.dev.json      # Development config
+├── config.prod.json     # Production config
+├── ccproxy.log         # Log file (when enabled)
+├── audit.log           # Audit log (when enabled)
+└── .ccproxy.pid        # Process ID file
 ```
 
-### .env.kimi-openrouter
-```bash
-# Kimi K2 via OpenRouter with fallbacks
-PROVIDER=openrouter
-OPENROUTER_API_KEY=sk-or-v1-your_key_here
-OPENROUTER_MODEL=moonshotai/kimi-k2-instruct
-OPENROUTER_SITE_NAME=YourApp
-LOG_LEVEL=info
-```
+### Dynamic Configuration Updates
 
-### .env.local-privacy
+Update provider configuration without restarting:
+
 ```bash
-# Complete privacy with Ollama
-PROVIDER=ollama
-OLLAMA_MODEL=llama3.2
-OLLAMA_BASE_URL=http://localhost:11434
-LOG_LEVEL=debug
+# Add a new provider
+curl -X POST http://localhost:3456/providers \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-ccproxy-api-key" \
+  -d '{
+    "name": "openai",
+    "api_key": "sk-...",
+    "enabled": true
+  }'
+
+# Disable a provider
+curl -X PUT http://localhost:3456/providers/openai \
+  -H "x-api-key: your-ccproxy-api-key" \
+  -d '{"enabled": false}'
+
+# Remove a provider
+curl -X DELETE http://localhost:3456/providers/openai \
+  -H "x-api-key: your-ccproxy-api-key"
 ```
 
 ## Validation
@@ -346,6 +523,6 @@ curl -X POST http://localhost:3456/v1/messages \
 
 - 📖 [Installation Guide](/guide/installation)
 - 🚀 [Quick Start](/guide/quick-start)  
-- ⭐ [Kimi K2 Setup](/kimi-k2)
+- 🔧 [Provider Guide](/providers/)
 - 💬 [Ask Questions](https://github.com/orchestre-dev/ccproxy/discussions) - Community support
 - 🐛 [Report Issues](https://github.com/orchestre-dev/ccproxy/issues) - Bug reports and feature requests

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -161,9 +161,7 @@ chmod +x ccproxy.AppImage
 ```bash
 # Run CCProxy in Docker
 docker run -p 3456:3456 \
-  -e PROVIDER=groq \
-  -e GROQ_API_KEY=your_api_key \
-  -e GROQ_MODEL=moonshotai/kimi-k2-instruct \
+  -v $(pwd)/config.json:/home/ccproxy/.ccproxy/config.json \
   orchestre-dev/ccproxy:latest
 ```
 
@@ -176,10 +174,8 @@ services:
     image: orchestre-dev/ccproxy:latest
     ports:
       - "3456:3456"
-    environment:
-      - PROVIDER=groq
-      - GROQ_API_KEY=${GROQ_API_KEY}
-      - GROQ_MODEL=moonshotai/kimi-k2-instruct
+    volumes:
+      - ./config.json:/home/ccproxy/.ccproxy/config.json
     restart: unless-stopped
 ```
 
@@ -210,14 +206,14 @@ spec:
         image: orchestre-dev/ccproxy:latest
         ports:
         - containerPort: 3456
-        env:
-        - name: PROVIDER
-          value: "groq"
-        - name: GROQ_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ccproxy-secrets
-              key: groq-api-key
+        volumeMounts:
+        - name: config
+          mountPath: /home/ccproxy/.ccproxy/config.json
+          subPath: config.json
+      volumes:
+      - name: config
+        configMap:
+          name: ccproxy-config
 ```
 
 </div>
@@ -232,7 +228,7 @@ git clone https://github.com/orchestre-dev/ccproxy.git
 cd ccproxy
 
 # Build for your platform
-go build -o ccproxy cmd/proxy/main.go
+go build -o ccproxy ./cmd/ccproxy
 
 # Or build for all platforms
 ./scripts/build.sh
@@ -251,14 +247,14 @@ curl http://localhost:3456/health
 
 # Configure for Claude Code
 export ANTHROPIC_BASE_URL=http://localhost:3456
-export ANTHROPIC_API_KEY=NOT_NEEDED
+export ANTHROPIC_AUTH_TOKEN=test
 ```
 
 ## Next Steps
 
-1. **[Configuration](/guide/configuration)** - Set up your AI provider
+1. **[Configuration](/guide/configuration)** - Set up your AI providers
 2. **[Quick Start](/guide/quick-start)** - Get up and running in 2 minutes
-3. **[Kimi K2 Setup](/kimi-k2)** - Experience ultra-fast AI development
+3. **[Provider Guide](/providers/)** - Supported AI providers
 
 ## Troubleshooting
 
@@ -274,8 +270,10 @@ Right-click the executable and select "Run anyway" or add an exception to Window
 
 **Port Already in Use:**
 ```bash
-# Use a different port
-ccproxy --port 8187
+# Edit config.json to use a different port
+{
+  "port": 8187
+}
 ```
 
 **Firewall Issues:**

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,55 +1,108 @@
 ---
 title: Quick Start - Get CCProxy Running in 2 Minutes
-description: Get CCProxy running with Kimi K2 and Claude Code in under 2 minutes. Fast setup guide for immediate AI development productivity.
-keywords: CCProxy quick start, Kimi K2 setup, Claude Code integration, AI proxy setup
+description: Get CCProxy running with Claude Code in under 2 minutes. Fast setup guide for immediate AI development productivity.
+keywords: CCProxy quick start, Claude Code integration, AI proxy setup
 ---
 
 # Quick Start
 
 <SocialShare />
 
-Get CCProxy running with Kimi K2 in under 2 minutes.
+Get CCProxy running with Claude Code in under 2 minutes.
 
-## 1. Install CCProxy
+## 1. Download CCProxy
+
+Download the latest binary for your platform from the [releases page](https://github.com/orchestre-dev/ccproxy/releases).
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/orchestre-dev/ccproxy/main/install.sh | bash
+# Example for macOS/Linux
+chmod +x ccproxy
 ```
 
-## 2. Start with Kimi K2
+## 2. Configure and Start
 
+Create a `config.json` file:
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "providers": [{
+    "name": "anthropic",
+    "api_key": "your-anthropic-api-key",
+    "enabled": true
+  }]
+}
+```
+
+Start CCProxy:
 ```bash
-export PROVIDER=groq GROQ_API_KEY=your_groq_api_key
-ccproxy &
+./ccproxy start
 ```
 
 ## 3. Connect Claude Code
 
+Use the auto-configuration:
+```bash
+./ccproxy code
+```
+
+Or configure manually:
 ```bash
 export ANTHROPIC_BASE_URL=http://localhost:3456
-claude-code "Write a Python function to reverse a string"
+export ANTHROPIC_AUTH_TOKEN=test
+claude "Write a Python function to reverse a string"
 ```
 
 ## 🎉 Done!
 
-Claude Code now uses your chosen AI provider. Try:
+Claude Code now uses your configured AI provider. Try:
 
 ```bash
-claude-code "Explain this code and suggest improvements" < your-file.py
-claude-code "Create a REST API for user management"
-claude-code "Debug this error: TypeError: 'int' object is not subscriptable"
+claude "Explain this code and suggest improvements" < your-file.py
+claude "Create a REST API for user management"
+claude "Debug this error: TypeError: 'int' object is not subscriptable"
+```
+
+## Multiple Providers
+
+Add more providers to your config.json:
+
+```json
+{
+  "providers": [
+    {
+      "name": "anthropic",
+      "api_key": "sk-ant-...",
+      "enabled": true
+    },
+    {
+      "name": "openai",
+      "api_key": "sk-...",
+      "enabled": true
+    },
+    {
+      "name": "gemini",
+      "api_key": "AI...",
+      "enabled": true
+    }
+  ]
+}
 ```
 
 ## Next Steps
 
 - **[Full Installation Guide](/guide/installation)** - Multiple installation methods
 - **[Configuration Guide](/guide/configuration)** - Advanced provider setup
-- **[Kimi K2 Guide](/kimi-k2)** - Optimize for ultra-fast development
+- **[Provider Guide](/providers/)** - Supported AI providers
 
 ## Troubleshooting
 
-**Connection refused?** Check if CCProxy is running on port 3456.
+**Connection refused?** Check if CCProxy is running:
+```bash
+./ccproxy status
+```
 
-**API key error?** Verify your provider API key is correct.
+**API key error?** Verify your provider API key in config.json.
 
 **Need help?** [💬 GitHub Discussions](https://github.com/orchestre-dev/ccproxy/discussions) • [🐛 Report Issues](https://github.com/orchestre-dev/ccproxy/issues)


### PR DESCRIPTION
## Summary
- Fixed all documentation to accurately reflect the current CCProxy Go implementation
- Removed references to non-existent providers and features
- Updated configuration examples to use JSON-based approach

## Changes Made

### Provider Updates
- Removed references to non-existent providers: Groq, XAI, Mistral, Ollama
- Updated supported providers to match actual transformers: Anthropic, OpenAI, Gemini, DeepSeek, OpenRouter
- Removed all references to "Kimi K2" model which doesn't exist

### Configuration Fixes
- Changed from environment variable-based configuration to JSON config files
- Updated all examples to use `config.json` approach
- Fixed port references from 7187 to 3456 throughout
- Updated Go version to 1.23 (was incorrectly showing 1.21 or 1.24)

### API Documentation
- Added authentication requirements for `/health` and `/status` endpoints
- Removed references to non-existent Prometheus `/metrics` endpoint
- Fixed response formats to match actual implementation
- Updated provider model mappings

### Guide Documentation
- Rewrote configuration.md to show JSON-based configuration
- Fixed environment.md to explain actual environment variable usage
- Updated installation.md with correct Docker/Kubernetes configurations
- Fixed quick-start.md to remove non-existent provider references

### Claude Code Integration
- Updated environment variables to use `ANTHROPIC_AUTH_TOKEN=test`
- Fixed all integration examples
- Added documentation for `ccproxy code` auto-configuration

### Build and Path Fixes
- Fixed binary build path from `cmd/proxy` to `cmd/ccproxy`
- Updated Docker examples to use config file volumes
- Fixed Kubernetes deployments to use ConfigMaps

## Test Plan
- [x] Verified all provider names match actual transformer implementations
- [x] Confirmed port 3456 is used consistently
- [x] Validated JSON configuration examples
- [x] Checked that all commands match actual CCProxy implementation
- [x] Ensured Go version 1.23 is referenced correctly