### PR TITLE
feat: add Product Hunt badge to docs homepage

### DIFF
--- a/docs/.vitepress/theme/components/Layout.vue
+++ b/docs/.vitepress/theme/components/Layout.vue
@@ -1,5 +1,10 @@
 <template>
   <DefaultTheme.Layout>
+    <template #layout-top>
+      <div v-if="isHomePage" class="product-hunt-wrapper">
+        <ProductHunt />
+      </div>
+    </template>
     <template #layout-bottom>
       <CookieConsent />
       <AnalyticsTracker />
@@ -11,12 +16,16 @@
 import DefaultTheme from 'vitepress/theme'
 import CookieConsent from './CookieConsent.vue'
 import AnalyticsTracker from './AnalyticsTracker.vue'
+import ProductHunt from './ProductHunt.vue'
 import { useAnalytics } from '../composables/useAnalytics'
 import { useRoute } from 'vitepress'
-import { watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { watch, onMounted, onUnmounted, nextTick, computed } from 'vue'
 
 const route = useRoute()
 const { trackPageView, trackScrollDepth, trackTimeOnPage, trackCodeCopy, trackOutboundLink } = useAnalytics()
+
+// Check if we're on the home page
+const isHomePage = computed(() => route.path === '/' || route.path === '/index.html')
 
 // Track initial page view
 onMounted(() => {
@@ -72,3 +81,13 @@ onUnmounted(() => {
   document.removeEventListener('click', clickHandler)
 })
 </script>
+
+<style scoped>
+.product-hunt-wrapper {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+}
+</style>

--- a/docs/.vitepress/theme/components/ProductHunt.vue
+++ b/docs/.vitepress/theme/components/ProductHunt.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="product-hunt-badge">
+    <a href="https://www.producthunt.com/products/ccproxy-any-ai-model-with-claude-code?embed=true&utm_source=badge-featured&utm_medium=badge&utm_source=badge-ccproxy" 
+       target="_blank"
+       rel="noopener noreferrer">
+      <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=996378&theme=light&t=1753258354865" 
+           alt="CCProxy - Keep Claude Code's magic, slash costs by 90% | Product Hunt" 
+           style="width: 250px; height: 54px;" 
+           width="250" 
+           height="54" />
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.product-hunt-badge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 12px 0;
+}
+
+.product-hunt-badge a {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.product-hunt-badge a:hover {
+  transform: translateY(-2px);
+}
+
+/* Dark mode support */
+.dark .product-hunt-badge {
+  filter: brightness(0.9);
+}
+
+/* Mobile responsive */
+@media (max-width: 640px) {
+  .product-hunt-badge img {
+    width: 200px !important;
+    height: 43px !important;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -6,6 +6,7 @@ import Layout from './components/Layout.vue'
 import Mermaid from 'vitepress-plugin-mermaid/Mermaid.vue'
 import NewsletterForm from './components/NewsletterForm.vue'
 import AnalyticsTracker from './components/AnalyticsTracker.vue'
+import ProductHunt from './components/ProductHunt.vue'
 import './style.css'
 
 export default {
@@ -21,6 +22,8 @@ export default {
     app.component('NewsletterForm', NewsletterForm)
     // Register the AnalyticsTracker component globally
     app.component('AnalyticsTracker', AnalyticsTracker)
+    // Register the ProductHunt component globally
+    app.component('ProductHunt', ProductHunt)
   },
   Layout
 }


### PR DESCRIPTION
## Summary

This PR adds a Product Hunt badge to the CCProxy documentation homepage to promote the Product Hunt launch and provide social proof for visitors.

### Changes

1. **Created ProductHunt.vue component** (`docs/.vitepress/theme/components/ProductHunt.vue`):
   - Displays the Product Hunt "Featured" badge
   - Responsive design (smaller on mobile)
   - Hover effect for better UX
   - Dark mode compatibility

2. **Updated VitePress theme** (`docs/.vitepress/theme/index.js`):
   - Registered ProductHunt component globally

3. **Modified Layout component** (`docs/.vitepress/theme/components/Layout.vue`):
   - Added ProductHunt badge to the `layout-top` slot
   - Conditional rendering - only shows on homepage
   - Absolute positioning at 60px from top, centered horizontally
   - Badge scrolls with page content (not fixed)

### Visual Details

- **Position**: 60px from top, horizontally centered
- **Behavior**: Scrolls with page content
- **Visibility**: Homepage only (route-based conditional)
- **Responsive**: Adapts size on mobile devices

### Benefits

- Increases visibility for the Product Hunt launch
- Provides social proof for new visitors
- Non-intrusive placement that doesn't block content
- Professional appearance that matches the site design

## Test Plan

- [x] Badge appears on homepage at specified position
- [x] Badge is centered horizontally
- [x] Badge scrolls with page content
- [x] Badge only appears on homepage, not other pages
- [x] Responsive sizing works on mobile
- [x] Dark mode compatibility
- [x] Hover effect works correctly