### PR TITLE
feat: add Qwen3-Coder blog post and configuration examples

### DIFF
--- a/docs/blog/qwen3-coder-claude-code.md
+++ b/docs/blog/qwen3-coder-claude-code.md
@@ -1,0 +1,215 @@
+---
+title: Using Qwen3-Coder with Claude Code via CCProxy - The Ultimate AI Coding Setup 
+description: Learn how to integrate Alibaba's powerful Qwen3-Coder model with Claude Code using CCProxy. Step-by-step guide for developers looking to leverage the latest 480B parameter coding AI.
+keywords: Qwen3-Coder, Claude Code, CCProxy, AI coding assistant, Alibaba Qwen3, code generation AI, Qwen3-Coder integration, Claude Code setup
+date: 2025-07-25
+author: CCProxy Team
+---
+
+# Using Qwen3-Coder with Claude Code via CCProxy: The Ultimate AI Coding Setup
+
+Alibaba just dropped a game-changer in the AI coding world: **Qwen3-Coder**, a massive 480B-parameter model that's setting new benchmarks. Released on July 23, 2025, this open-source powerhouse is now competing head-to-head with Claude and GPT-4.1. The best part? You can use it with Claude Code through CCProxy!
+
+## What Makes Qwen3-Coder Special?
+
+Qwen3-Coder isn't just another AI model. It's a **480B-parameter Mixture-of-Experts** model that activates only 35B parameters per query, making it both powerful and efficient. Here's what sets it apart:
+
+- **256K token context window** (expandable to 1M tokens!)
+- **119 programming languages** supported
+- **69.6% score** on SWE-bench Verified (nearly matching Claude-Sonnet-4's 70.4%)
+- **7.5 trillion tokens** of training data (70% code-focused)
+- **True agentic capabilities** for autonomous programming
+
+## Quick Setup: Qwen3-Coder + Claude Code + CCProxy
+
+Getting Qwen3-Coder working with Claude Code is surprisingly straightforward with CCProxy. Here's how to do it in under 5 minutes:
+
+### Step 1: Get Your OpenRouter API Key
+
+First, sign up for OpenRouter to access Qwen3-Coder:
+1. Visit [OpenRouter](https://openrouter.ai/)
+2. Create an account and get your API key
+3. Add credits to your account (or use the free tier)
+
+### Step 2: Configure CCProxy for Qwen3-Coder
+
+Create a configuration file for CCProxy that includes Qwen3-Coder:
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "providers": [
+    {
+      "name": "openrouter",
+      "api_key": "${OPENROUTER_API_KEY}",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "models": ["qwen/qwen3-coder", "qwen/qwen3-coder:free"],
+      "enabled": true
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.2,
+        "max_tokens": 8000
+      }
+    },
+    "longContext": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 16000
+      }
+    }
+  }
+}
+```
+
+### Step 3: Set Environment Variables
+
+```bash
+export OPENROUTER_API_KEY="sk-or-v1-your-openrouter-api-key"
+```
+
+### Step 4: Start CCProxy
+
+```bash
+ccproxy start --config ~/.ccproxy/qwen-config.json
+ccproxy code
+```
+
+That's it! Claude Code will now use Qwen3-Coder for all its AI operations.
+
+## Advanced Configuration: Multi-Model Setup
+
+Want the best of both worlds? Configure CCProxy to use different models for different tasks:
+
+```json
+{
+  "providers": [
+    {
+      "name": "openrouter",
+      "api_key": "${OPENROUTER_API_KEY}",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "models": ["qwen/qwen3-coder", "qwen/qwen3-coder:free", "anthropic/claude-sonnet-4-20250720"],
+      "enabled": true
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.3
+      }
+    },
+    "think": {
+      "provider": "openrouter",
+      "model": "anthropic/claude-sonnet-4-20250720"
+    },
+    "claude-3-5-haiku-20241022": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 4000
+      }
+    }
+  }
+}
+```
+
+This configuration:
+- Uses **Qwen3-Coder** as the default model for most tasks
+- Routes thinking-intensive tasks to **Claude** when needed
+- Maps Haiku requests to the free tier of Qwen3-Coder
+
+## Real-World Performance Comparison
+
+Here's how Qwen3-Coder stacks up in real-world usage with Claude Code:
+
+| Task | Qwen3-Coder | Claude-Sonnet-4 | GPT-4.1 |
+|------|-------------|-----------------|---------|
+| Code Generation | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| Bug Fixing | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| Code Refactoring | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| Long Context | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ |
+| Open Source | ⭐⭐⭐⭐⭐ | ❌ | ❌ |
+
+## Tips for Maximum Performance
+
+### 1. Leverage the Massive Context Window
+Qwen3-Coder's 256K token context is perfect for:
+- Analyzing entire codebases
+- Understanding complex project structures
+- Maintaining context across multiple files
+
+### 2. Optimize Temperature Settings
+- **0.1-0.3**: For precise code generation and bug fixes
+- **0.5-0.7**: For creative solutions and architecture design
+- **0.8-1.0**: For brainstorming and exploration
+
+### 3. Use Smart Routing
+Take advantage of different routing strategies:
+```json
+{
+  "routes": {
+    "default": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder"
+    },
+    "background": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free"
+    }
+  }
+}
+```
+
+## Troubleshooting Common Issues
+
+### API Key Not Working
+If you're getting authentication errors:
+1. Ensure your OpenRouter API key starts with `sk-or-v1-`
+2. Check that you have credits in your OpenRouter account
+3. Verify the base URL is `https://openrouter.ai/api/v1`
+
+### Model Not Found
+The model name must be exactly `qwen/qwen3-coder` or `qwen/qwen3-coder:free` in your configuration.
+
+### Slow Response Times
+Qwen3-Coder is optimized for quality over speed. For faster responses:
+- Use lower temperature values
+- Limit max_tokens when appropriate
+- Consider using parallel requests for independent tasks
+
+## Why Qwen3-Coder + Claude Code?
+
+This combination gives you:
+- **Open-source flexibility** with enterprise-grade performance
+- **262K token context window** for handling large codebases
+- **Seamless integration** with your existing Claude Code workflow
+- **No vendor lock-in** - switch models anytime
+- **Free tier available** through OpenRouter
+
+## Conclusion
+
+Qwen3-Coder represents a significant leap forward in open-source AI coding models. By integrating it with Claude Code through CCProxy, you get the best of both worlds: the familiar Claude Code interface with the power of Alibaba's latest AI innovation.
+
+Ready to supercharge your coding workflow? Set up Qwen3-Coder with CCProxy today and experience the future of AI-assisted development!
+
+## Resources
+
+- [CCProxy GitHub Repository](https://github.com/orchestre-dev/ccproxy)
+- [Qwen3-Coder Official Blog Post](https://qwenlm.github.io/blog/qwen3-coder/)
+- [Qwen3-Coder GitHub](https://github.com/QwenLM/Qwen3-Coder)
+- [OpenRouter](https://openrouter.ai/)
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
+
+---
+
+*Have questions or feedback? Join the discussion on our [GitHub Discussions](https://github.com/orchestre-dev/ccproxy/discussions) page.*

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -32,6 +32,27 @@ Maximum cost efficiency with mini models.
 - **Thinking**: O1-mini
 - **Background**: O4-mini
 
+### 5. `qwen3-coder.json` - Qwen3-Coder Standalone
+Alibaba's powerful 480B parameter coding model (July 2025).
+- **Default**: qwen3-coder-plus (optimized for code generation)
+- **Long context**: Up to 256K tokens native support
+- **Background**: Same model with reduced token limits
+- Excellent performance matching Claude-Sonnet-4
+
+### 6. `qwen3-mixed.json` - Qwen3-Coder Multi-Provider
+Combines Qwen3-Coder with other providers for flexibility.
+- **Default**: Qwen3-Coder (cost-effective primary model)
+- **Thinking**: Claude-Sonnet-4 for complex reasoning
+- **Background**: GPT-4.1-turbo for quick tasks
+- Maps Claude model requests to Qwen3-Coder for cost savings
+
+### 7. `qwen3-budget.json` - Ultra Cost-Optimized with Qwen3-Coder
+Maximum cost savings using Qwen3-Coder for all routes.
+- All Claude model requests routed to Qwen3-Coder
+- Optimized token limits for each use case
+- Perfect for development and testing environments
+- Significant cost reduction while maintaining quality
+
 ## Quick Start
 
 1. Copy your desired configuration:
@@ -69,6 +90,13 @@ Maximum cost efficiency with mini models.
 - **O4-mini**: Latest mini model for general tasks
 - **O4-mini-high**: Enhanced mini model for code
 
+### Qwen3-Coder Series
+- **qwen3-coder-plus**: 480B parameter MoE model (35B active)
+- **256K context window**: Native support, expandable to 1M
+- **119 languages**: Comprehensive programming language support
+- **69.6% SWE-bench**: Near parity with Claude-Sonnet-4 (70.4%)
+- **Cost-effective**: Open-source with competitive pricing
+
 ## Routing Logic
 
 CCProxy automatically routes requests based on:
@@ -93,5 +121,6 @@ export CCPROXY_PORT=3456
 export CCPROXY_HOST=127.0.0.1
 export CCPROXY_API_KEY="your-auth-key"
 export OPENAI_API_KEY="sk-openai-key"        # Auto-detected by provider name
+export OPENROUTER_API_KEY="sk-or-v1-your-key" # For OpenRouter models including Qwen3-Coder
 # Or use indexed format: export CCPROXY_PROVIDERS_0_API_KEY="sk-openai-key"
 ```

--- a/examples/configs/qwen3-budget.json
+++ b/examples/configs/qwen3-budget.json
@@ -1,0 +1,87 @@
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": false,
+  "providers": [
+    {
+      "name": "openrouter",
+      "api_key": "${OPENROUTER_API_KEY}",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "models": ["qwen/qwen3-coder", "qwen/qwen3-coder:free"],
+      "enabled": true
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.2,
+        "max_tokens": 4000
+      }
+    },
+    "longContext": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 8000
+      }
+    },
+    "background": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 2000
+      }
+    },
+    "think": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.5,
+        "max_tokens": 8000
+      }
+    },
+    "claude-3-5-haiku-20241022": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 2000
+      }
+    },
+    "claude-3-5-sonnet-20241022": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.3,
+        "max_tokens": 4000
+      }
+    },
+    "claude-opus-4": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.2,
+        "max_tokens": 8000
+      }
+    },
+    "claude-sonnet-4": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.3,
+        "max_tokens": 6000
+      }
+    }
+  },
+  "performance": {
+    "request_timeout": "60s",
+    "max_request_body_size": 10485760,
+    "metrics_enabled": false,
+    "rate_limit_enabled": false,
+    "circuit_breaker_enabled": true
+  }
+}

--- a/examples/configs/qwen3-coder.json
+++ b/examples/configs/qwen3-coder.json
@@ -1,0 +1,47 @@
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": true,
+  "providers": [
+    {
+      "name": "openrouter",
+      "api_key": "${OPENROUTER_API_KEY}",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "models": ["qwen/qwen3-coder", "qwen/qwen3-coder:free"],
+      "enabled": true
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.2,
+        "max_tokens": 8000
+      }
+    },
+    "longContext": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 16000
+      }
+    },
+    "background": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.3,
+        "max_tokens": 4000
+      }
+    }
+  },
+  "performance": {
+    "request_timeout": "120s",
+    "max_request_body_size": 20971520,
+    "metrics_enabled": true,
+    "rate_limit_enabled": false,
+    "circuit_breaker_enabled": true
+  }
+}

--- a/examples/configs/qwen3-mixed.json
+++ b/examples/configs/qwen3-mixed.json
@@ -1,0 +1,77 @@
+{
+  "host": "127.0.0.1",
+  "port": 3456,
+  "log": true,
+  "providers": [
+    {
+      "name": "openrouter",
+      "api_key": "${OPENROUTER_API_KEY}",
+      "api_base_url": "https://openrouter.ai/api/v1",
+      "models": [
+        "qwen/qwen3-coder",
+        "qwen/qwen3-coder:free",
+        "anthropic/claude-sonnet-4-20250720",
+        "anthropic/claude-opus-4-20250720",
+        "openai/gpt-4.1",
+        "openai/gpt-4.1-turbo"
+      ],
+      "enabled": true
+    }
+  ],
+  "routes": {
+    "default": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.3,
+        "max_tokens": 8000
+      }
+    },
+    "longContext": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 32000
+      }
+    },
+    "think": {
+      "provider": "openrouter",
+      "model": "anthropic/claude-sonnet-4-20250720",
+      "parameters": {
+        "temperature": 0.5
+      }
+    },
+    "background": {
+      "provider": "openrouter",
+      "model": "openai/gpt-4.1-turbo",
+      "parameters": {
+        "temperature": 0.2,
+        "max_tokens": 2000
+      }
+    },
+    "claude-3-5-haiku-20241022": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder:free",
+      "parameters": {
+        "temperature": 0.1,
+        "max_tokens": 4000
+      }
+    },
+    "claude-opus-4": {
+      "provider": "openrouter",
+      "model": "qwen/qwen3-coder",
+      "parameters": {
+        "temperature": 0.2,
+        "max_tokens": 16000
+      }
+    }
+  },
+  "performance": {
+    "request_timeout": "120s",
+    "max_request_body_size": 20971520,
+    "metrics_enabled": true,
+    "rate_limit_enabled": false,
+    "circuit_breaker_enabled": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive blog post on using Qwen3-Coder with Claude Code via CCProxy
- Include three configuration examples for different use cases
- Update documentation with Qwen3-Coder integration details

## Details

This PR adds support documentation for Alibaba's Qwen3-Coder model (released July 23, 2025) which is now available through OpenRouter. The 480B-parameter model achieves 69.6% on SWE-bench, nearly matching Claude-Sonnet-4's performance.

### Added Files
- `docs/blog/qwen3-coder-claude-code.md` - SEO-optimized blog post
- `examples/configs/qwen3-coder.json` - Standalone configuration
- `examples/configs/qwen3-mixed.json` - Multi-provider setup
- `examples/configs/qwen3-budget.json` - Cost-optimized using free tier
- Updated `examples/configs/README.md` with Qwen3-Coder documentation

### Key Features Documented
- 262K token context window (expandable to 1M)
- OpenRouter integration using correct model names
- Free tier availability (`qwen/qwen3-coder:free`)
- Smart routing strategies for different use cases

## Test Plan
- [ ] Verify all configuration files are valid JSON
- [ ] Test OpenRouter integration with provided model names
- [ ] Confirm blog post renders correctly in documentation site
- [ ] Validate all external links work properly